### PR TITLE
feature: setup plugin to filter out any file except javascript before process them

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ function reporter(options, files) {
     var output = '';
 
     files.forEach(file => {
+      // exit cycle if file is not a JavaScript
+      if (['.js'].indexOf(path.extname(file)) < 0) {
+        return;
+      }
+
       var todo = leasot.parse({
         ext:        path.extname(file),
         content:    fs.readFileSync(file, 'utf8'),


### PR DESCRIPTION
Hi Mike,

Recently, I was using your plugin in one of my project and I found out that there is an issue with leasot parser. It was trying to process every files that was supplied by Webpack and failed with message:

```
node_modules\leasot\lib\parsers.js:86
        throw new Error('extension ' + ext + ' is not supported.');
        ^
Error: extension .ttf is not supported.
```

So, here is my proposal to filter out any file except JS before send it to leasot parser.

Or if you have any other idea on how I should setup webpack to deal with this situation, then, please, let me know. Thanks.
