### PR TITLE
withInlineFiles leasot option (#9)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ const DEFAULT_OPTIONS = {
   reporter:           'markdown', // default markdown
   skipUnsupported:    true,       // skip unsupported files
   suppressFileOutput: false,      // don't output to file,
-  relativeFilePath:   true        // display relative file paths in report
+  relativeFilePath:   true,       // display relative file paths in report
+  withInlineFiles:    false       // parse possible inline files
 };
 
 function TodoWebpackPlugin(options) {
@@ -41,11 +42,12 @@ function reporter(options, files) {
         }
       }
       var todo = leasot.parse({
-        ext:        path.extname(file),
-        content:    fs.readFileSync(file, 'utf8'),
-        fileName:   file,
-        customTags: options.tags,
-        reporter:   options.reporter,
+        ext:              path.extname(file),
+        content:          fs.readFileSync(file, 'utf8'),
+        fileName:         file,
+        customTags:       options.tags,
+        reporter:         options.reporter,
+        withInlineFiles:  options.withInlineFiles
       });
       todos = todos.concat(todo);
     });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mocha": "3.2.0"
   },
   "dependencies": {
-    "leasot": "4.3.0"
+    "leasot": "4.3.1"
   },
   "engine": "node >= 0.4.4",
   "reveal": true


### PR DESCRIPTION
Adds support for `.vue` files.  To use in webpack, update your `TodoWebpackPlugin` options:

```
plugins: [
    new TodoWebpackPlugin({
        withInlineFiles: true
    })
]
```