### PR TITLE
Handle the case where files is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ TodoWebpackPlugin.prototype = {
 function reporter(options, files) {
   let todos = [];
   let output = '';
-  let testFiles = files;
+  let testFiles = files ? files : [];
 
   testFiles.forEach(file => {
     if (options.skipUnsupported) {


### PR DESCRIPTION
With the version 1.9.6 (and also with the changes in HEAD) I am getting an error trying to call ForEach on undefined.  This fixes it.  Older versions appeared to initialize testFiles to [] and build it up.